### PR TITLE
Add `http_scheme` for fix honor http_scheme in Data Contract for Trino connections

### DIFF
--- a/src/open_data_contract_standard/model.py
+++ b/src/open_data_contract_standard/model.py
@@ -208,6 +208,7 @@ class Server(pyd.BaseModel):
     stagingDir: str | None = None
     stream: str | None = None
     warehouse: str | None = None
+    http_scheme: str | None = None
 
 
 


### PR DESCRIPTION
### Summary

This PR add `http_scheme` propertie for fixes an issue where the `http_scheme` defined in `data-contract.yml` was ignored during the conversion from DCS to ODCS.

Trino connections in soda-core are `https`, even when `http` was explicitly configured. This breaks common local and non-SSL setups.

### Root Cause

Although `http_scheme` is a valid field in the Data Contract specification, it was not being propagated during the internal model transformation (DCS → ODCS). Consequently, the value never reached the connection layer in soda-core.

### Changes

* Added `http_scheme` to the `Server` model in both:

  * DCS (Data Contract Specification)
  * ODCS (Operational Data Contract Specification)
* Fixed the mapping logic to ensure the field is preserved during DCS → ODCS conversion
* Ensured the value is correctly passed to the soda-core connection layer

### Why this matters

The Trino connector in soda-core supports `http_scheme="http"` as the official way to connect to instances without SSL (e.g., local environments), as seen in:

* [`trino_data_source_connection.py`](https://github.com/sodadata/soda-core/blob/main/soda-trino/src/soda_trino/common/data_sources/trino_data_source_connection.py#L24)

Without this fix, users cannot connect to:

* Local Trino instances
* Test environments without HTTPS
* Custom deployments without SSL/Auth

### Example

```yaml
server:
  host: localhost
  port: 8080
  http_scheme: http
```

Before this fix:

* `http_scheme` was ignored → connection attempted via `https`

After this fix:

* `http_scheme` is respected → connection uses `http` as expected

### Impact

* Enables local development workflows with Trino